### PR TITLE
fix(macros): Start board fan at print start

### DIFF
--- a/config/gcode_macro.cfg
+++ b/config/gcode_macro.cfg
@@ -156,6 +156,7 @@ gcode:
 
 [gcode_macro PRINT_START]
 gcode:
+    SET_FAN_SPEED FAN=board_fan SPEED=0.5
     # Load Z offset, cancel if none is set
     {% set gcode_offset = printer.gcode_move.homing_origin.z|float %}
     {% set auto_z_offset = printer.configfile.config.auto_z_offset.calibrated_z_offset|float %}


### PR DESCRIPTION
Added board fan at PRINT_START to help with motors while heating the chamber.