### PR TITLE
Fix nozzle cooldown in RESUME macro

### DIFF
--- a/config/gcode_macro.cfg
+++ b/config/gcode_macro.cfg
@@ -373,7 +373,7 @@ gcode:
         G91
         G1  E{e} F300                                                ; prime nozzle by E, lower Z back down
         G90
-        CLEAR_NOZZLE
+        CLEAR_NOZZLE HOTEND={etemp|int} COOLDOWN=0
         G1 Y200 F3000
         RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=200
         RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=10                         ; restore position


### PR DESCRIPTION
Current use of the `CLEAR_NOZZLE` macro within the `RESUME` macro causes the print to fail because of the improper invocation.

This PR fixes the issue.