### PR TITLE
Remove calls to missing CLEAR_LAST_FILE macro

### DIFF
--- a/config/gcode_macro.cfg
+++ b/config/gcode_macro.cfg
@@ -297,7 +297,6 @@ gcode:
     DISABLE_FILAMENT_SENSORS
     SET_GCODE_OFFSET Z=0 MOVE=0
     BED_MESH_CLEAR
-    CLEAR_LAST_FILE
     BEEP I=2 DUR=500
 
 [gcode_macro CANCEL_PRINT]
@@ -323,7 +322,6 @@ gcode:
     BEEP I=2 DUR=500
 
     BASE_CANCEL_PRINT
-    CLEAR_LAST_FILE
 
 [gcode_macro PAUSE]
 rename_existing: BASE_PAUSE


### PR DESCRIPTION
Removes calls to a missing `CLEAR_LAST_FILE` macro and cleans up the console output.