### PR TITLE
Update gcode_macro.cfg

### DIFF
--- a/config/gcode_macro.cfg
+++ b/config/gcode_macro.cfg
@@ -208,8 +208,8 @@ gcode:
     M84.1
     SET_STEPPER_ENABLE STEPPER=stepper_x enable=0
     SET_STEPPER_ENABLE STEPPER=stepper_y enable=0
-    SET_STEPPER_ENABLE STEPPER=stepper_z enable=1
-    SET_STEPPER_ENABLE STEPPER=stepper_z1 enable=1
+    SET_STEPPER_ENABLE STEPPER=stepper_z enable=0
+    SET_STEPPER_ENABLE STEPPER=stepper_z1 enable=0    ; print bed doesnt slide due to gravity so this change is made to reduce power draw
     SET_STEPPER_ENABLE STEPPER=extruder enable=0
 
 [homing_override]
@@ -228,7 +228,7 @@ gcode:
         {% set HOME_Z = 1 %}
         {% set HOME_ALL = 1 %}
 
-        SET_KINEMATIC_POSITION Z={printer.toolhead.axis_maximum.z-5}
+        SET_KINEMATIC_POSITION Z=242 ; print bed moves away the nozzle by 5mm, out of range fixes  
         G91
         G1 Z5 F600
         {% if printer.save_variables.variables.at_bucket %}


### PR DESCRIPTION
Update M84 to disable motor (print bed would stay in place and decreasing power consumption ~5W)
attempt on fixes out of range issue

P.S. My unit only have 243mm range from the nozzle, so after printing a full height (hopefully no one does for now), the z-axis will collide with the bottom of the machine (~240mm + 5mm homing) w/o changing the slicer settings.  