### PR TITLE
Change on_error_gcode from PAUSE to CANCEL_PRINT

### DIFF
--- a/config/printer.cfg
+++ b/config/printer.cfg
@@ -2,7 +2,7 @@
 
 [virtual_sdcard]
 path: ~/printer_data/gcodes
-on_error_gcode: PAUSE
+on_error_gcode: CANCEL_PRINT
 
 [save_variables]
 filename: ~/printer_data/config/saved_variables.cfg


### PR DESCRIPTION
I ran into an issue where I started a print, but immediately hit a fatal error ("Must home axis first"). This triggered the `on_error_gcode: PAUSE`. `PAUSE` ran and called `PAUSE_BASE`, which successfully set `is_paused = True`, but then `_TOOLHEAD_PARK_PAUSE_CANCEL` also failed trying to move unhomed axes. The macro chain aborted. 

The problem here is that the pause was never cancelled. When I ran my next print and tried to pause it, the `PAUSE` command just had no effect at all.

Related log:

```
Starting SD card print (position 0)
Must home axis first: 0.000 0.000 148.194 [32090.261]
Filament width sensor is already Off
Must home axis first: 0.000 0.000 152.894 [32090.261]
Must home axis first: 0.000 0.000 152.894 [32090.261]
virtual_sdcard on_error
Traceback (most recent call last):
  File "/home/mks/klipper/klippy/extras/virtual_sdcard.py", line 273, in work_handler
    self.gcode.run_script(line)
  File "/home/mks/klipper/klippy/gcode.py", line 230, in run_script
    self._process_commands(script.split('\n'), need_ack=False)
  File "/home/mks/klipper/klippy/gcode.py", line 212, in _process_commands
    handler(gcmd)
  File "/home/mks/klipper/klippy/gcode.py", line 140, in <lambda>
    func = lambda params: origfunc(self._get_extended_params(params))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mks/klipper/klippy/extras/gcode_move.py", line 222, in cmd_SET_GCODE_OFFSET
    self.move_with_transform(self.last_position, speed)
  File "/home/mks/klipper/klippy/extras/bed_mesh.py", line 224, in move
    self.toolhead.move(split_move, speed)
  File "/home/mks/klipper/klippy/toolhead.py", line 383, in move
    self.kin.check_move(move)
  File "/home/mks/klipper/klippy/kinematics/corexy.py", line 77, in check_move
    self._check_endstops(move)
  File "/home/mks/klipper/klippy/kinematics/corexy.py", line 70, in _check_endstops
    raise move.move_error("Must home axis first")
gcode.CommandError: Must home axis first: 0.000 0.000 148.194 [32090.261]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mks/klipper/klippy/extras/virtual_sdcard.py", line 277, in work_handler
    self.gcode.run_script(self.on_error_gcode.render())
  File "/home/mks/klipper/klippy/gcode.py", line 230, in run_script
    self._process_commands(script.split('\n'), need_ack=False)
  File "/home/mks/klipper/klippy/gcode.py", line 212, in _process_commands
    handler(gcmd)
  File "/home/mks/klipper/klippy/gcode.py", line 140, in <lambda>
    func = lambda params: origfunc(self._get_extended_params(params))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mks/klipper/klippy/extras/gcode_macro.py", line 195, in cmd
    self.template.run_gcode_from_command(kwparams)
  File "/home/mks/klipper/klippy/extras/gcode_macro.py", line 74, in run_gcode_from_command
    self.gcode.run_script_from_command(self.render(context))
  File "/home/mks/klipper/klippy/gcode.py", line 227, in run_script_from_command
    self._process_commands(script.split('\n'), need_ack=False)
  File "/home/mks/klipper/klippy/gcode.py", line 212, in _process_commands
    handler(gcmd)
  File "/home/mks/klipper/klippy/extras/gcode_move.py", line 157, in cmd_G1
    self.move_with_transform(self.last_position, self.speed)
  File "/home/mks/klipper/klippy/extras/bed_mesh.py", line 224, in move
    self.toolhead.move(split_move, speed)
  File "/home/mks/klipper/klippy/toolhead.py", line 383, in move
    self.kin.check_move(move)
  File "/home/mks/klipper/klippy/kinematics/corexy.py", line 77, in check_move
    self._check_endstops(move)
  File "/home/mks/klipper/klippy/kinematics/corexy.py", line 70, in _check_endstops
    raise move.move_error("Must home axis first")
gcode.CommandError: Must home axis first: 0.000 0.000 152.894 [32090.261]
Exiting SD card print (position 15631)
```